### PR TITLE
Fix: Camera 관련하여 재설정하던 버그 수정

### DIFF
--- a/challenges/multicapture/run.py
+++ b/challenges/multicapture/run.py
@@ -293,13 +293,6 @@ for frame in range(FLAGS.frame_start - 1, FLAGS.frame_end + 2):
   scene.camera.keyframe_insert("position", frame)
   scene.camera.keyframe_insert("quaternion", frame)
 
-for frame in range(FLAGS.frame_start - 1, FLAGS.frame_end + 2):
-  scene.camera.position = kb.sample_point_in_half_sphere_shell(
-      inner_radius=FLAGS.min_radius, outer_radius=FLAGS.max_radius, offset=0.1)
-  scene.camera.look_at((0, 0, 0))
-  scene.camera.keyframe_insert("position", frame)
-  scene.camera.keyframe_insert("quaternion", frame)
-
 
 logging.info("Rendering the test scene ...")
 simulator.scratch_dir = scratch_test_dir


### PR DESCRIPTION
## PR의 목적
- Test camera 위치가 train 때 발견하지 못한 부분에 대해서도 나오고 있음을 확인.
- 해당 부분에 대해서 4DGS의 학습 결과가 많이 떨어지는 모습을 보였고, 관련하여 수정이 필요하다는 것을 확인하였음. 

## Commit List 
- Commit [`f335be9`](https://github.com/jeongyw12382/kubric_gpu/commit/f335be94046a7314397036b77295f795528819cd): fix: remove camera resampling
    - camera 좌표를 초기화하고 다시 설정하던 버그 수정